### PR TITLE
Remove mocklab references and replace with wiremock

### DIFF
--- a/src/main/java/org/wiremock/extension/jwt/JwtHandlebarsHelper.java
+++ b/src/main/java/org/wiremock/extension/jwt/JwtHandlebarsHelper.java
@@ -54,8 +54,8 @@ public class JwtHandlebarsHelper extends HandlebarsHelper<Object> {
         JWTCreator.Builder tokenBuilder = JWT.create()
                 .withExpiresAt(expiryDate)
                 .withIssuedAt(new Date())
-                .withIssuer(getOptionOrDefault(options, "iss", "mocklab"))
-                .withAudience(getOptionOrDefault(options, "aud", "mocklab.io"))
+                .withIssuer(getOptionOrDefault(options, "iss", "wiremock"))
+                .withAudience(getOptionOrDefault(options, "aud", "wiremock.io"))
                 .withSubject(getOptionOrDefault(options, "sub", "user-123"));
 
         if (options.hash.containsKey("nbf")) {

--- a/src/test/java/org/wiremock/extension/jwt/JwtHelperAcceptanceTest.java
+++ b/src/test/java/org/wiremock/extension/jwt/JwtHelperAcceptanceTest.java
@@ -74,8 +74,8 @@ public class JwtHelperAcceptanceTest {
   void produces_default_jwt_with_100_year_lifetime_when_no_parameters_specified() {
     DecodedJWT decodedJwt = verifyHs256AndDecodeForTemplate("{{jwt}}");
 
-    assertThat(decodedJwt.getIssuer(), is("mocklab"));
-    assertThat(decodedJwt.getAudience().get(0), is("mocklab.io"));
+    assertThat(decodedJwt.getIssuer(), is("wiremock"));
+    assertThat(decodedJwt.getAudience().get(0), is("wiremock.io"));
     inLastFewSeconds(decodedJwt.getIssuedAt());
     inTheFutureFrom(decodedJwt.getExpiresAt(), decodedJwt.getIssuedAt(), 36500, DAYS);
   }
@@ -128,9 +128,9 @@ public class JwtHelperAcceptanceTest {
   @Test
   void produces_a_JWT_with_the_supplied_issuer() {
     DecodedJWT decodedJwt =
-        verifyHs256AndDecodeForTemplate("{{jwt iss='https://jwt-example.mocklab.io/'}}");
+        verifyHs256AndDecodeForTemplate("{{jwt iss='https://jwt-example.wiremock.io/'}}");
 
-    assertThat(decodedJwt.getIssuer(), is("https://jwt-example.mocklab.io/"));
+    assertThat(decodedJwt.getIssuer(), is("https://jwt-example.wiremock.io/"));
   }
 
   @Test
@@ -143,16 +143,16 @@ public class JwtHelperAcceptanceTest {
   @Test
   void produces_a_JWT_with_the_supplied_single_audience() {
     DecodedJWT decodedJwt =
-        verifyHs256AndDecodeForTemplate("{{jwt aud='https://jwt-target.mocklab.io/'}}");
+        verifyHs256AndDecodeForTemplate("{{jwt aud='https://jwt-target.wiremock.io/'}}");
 
-    assertThat(decodedJwt.getAudience().get(0), is("https://jwt-target.mocklab.io/"));
+    assertThat(decodedJwt.getAudience().get(0), is("https://jwt-target.wiremock.io/"));
   }
 
   @Test
   void produces_a_JWT_with_custom_claims() {
     DecodedJWT decodedJwt =
         verifyHs256AndDecodeForTemplate(
-            "{{jwt sub='superuser' isAdmin=true quota=23 score=0.96 email='superuser@example.mocklab.io' signupDate=(parseDate '2017-01-02T03:04:05Z')}}");
+            "{{jwt sub='superuser' isAdmin=true quota=23 score=0.96 email='superuser@example.wiremock.io' signupDate=(parseDate '2017-01-02T03:04:05Z')}}");
 
     assertThat(decodedJwt.getSubject(), is("superuser"));
     Map<String, Claim> claims = decodedJwt.getClaims();
@@ -160,7 +160,7 @@ public class JwtHelperAcceptanceTest {
     assertThat(claims.get("isAdmin").asBoolean(), is(true));
     assertThat(claims.get("quota").asInt(), is(23));
     assertThat(claims.get("score").asDouble(), is(0.96));
-    assertThat(claims.get("email").asString(), is("superuser@example.mocklab.io"));
+    assertThat(claims.get("email").asString(), is("superuser@example.wiremock.io"));
     assertThat(claims.get("signupDate").asDate(), is(Dates.parse("2017-01-02T03:04:05Z")));
   }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR updates all references to `mocklab` to `wiremock`

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
