### PR TITLE
chore: Fix transitive vulnerability in jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ dependencies {
   implementation "org.bitbucket.b_c:jose4j:$versions.jose4j"
   implementation 'org.apache.commons:commons-lang3:3.17.0'
   implementation 'commons-codec:commons-codec:1.17.1'
+
+  constraints {
+    implementation('com.fasterxml.jackson.core:jackson-core:2.15.0') {
+      because 'version 2.14.2 brought in transitively by com.auth0:auth0@2.12.0 has CWE-400'
+    }
+  }
 }
 
 shadowJar {


### PR DESCRIPTION
Set the minimum version to 2.15.0. Version 2.14.2 brought in
transitively by com.auth0:auth0@2.12.0 has CWE-400.

A gradle constraint does not fix the version, just sets a minimum
version: https://www.linen.dev/s/gradle-community/t/22694678/hi-snyk-has-revealed-that-some-deeply-nested-transitive-depe#e46476e5-70e1-49a7-a72f-fa5453374e42

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
