### PR TITLE
added support for nested objects

### DIFF
--- a/src/main/java/org/wiremock/extension/jwt/JwtHandlebarsHelper.java
+++ b/src/main/java/org/wiremock/extension/jwt/JwtHandlebarsHelper.java
@@ -10,7 +10,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -98,6 +100,8 @@ public class JwtHandlebarsHelper extends HandlebarsHelper<Object> {
                         builder.withClaim(key, (Date) value);
                     } else if (value instanceof List) {
                         toArray(builder, key, (List<?>) value);
+                    } else if (value instanceof Map) {
+                        builder.withClaim(key, (Map<String, Object>) value);
                     }
                 });
     }

--- a/src/main/java/org/wiremock/extension/jwt/JwtHelpersExtension.java
+++ b/src/main/java/org/wiremock/extension/jwt/JwtHelpersExtension.java
@@ -19,8 +19,8 @@ public class JwtHelpersExtension implements TemplateHelperProviderExtension {
         return Map.of(
                 "jwt", jwtHandlebarsHelper,
                 "claims", new ClaimListHandlebarsHelper(),
-                "jwks", jwksHandlebarsHelper
-        );
+                "object", new ObjectHandlebarsHelper(),
+                "jwks", jwksHandlebarsHelper);
     }
 
     @Override

--- a/src/main/java/org/wiremock/extension/jwt/ObjectHandlebarsHelper.java
+++ b/src/main/java/org/wiremock/extension/jwt/ObjectHandlebarsHelper.java
@@ -1,0 +1,35 @@
+package org.wiremock.extension.jwt;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.github.jknack.handlebars.Options;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
+
+public class ObjectHandlebarsHelper extends HandlebarsHelper<Object> {
+
+    @Override
+    public Object apply(Object context, Options options) {
+        Map<String, Object> result = new HashMap<>();
+
+        // Process each key-value pair from the options hash
+        options.hash.forEach((key, value) -> {
+            // Convert each key-value pair to a nested structure if the key contains dots
+            Map<String, Object> map = new HashMap<>();
+            map.put(key, value);
+            result.putAll(map);
+        });
+
+        return result;
+    }
+
+    private static Map<String, Object> convertToNestedStructure(String key, Object value) {
+        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> current = result;
+
+        // Put the actual value at the deepest level
+        current.put(key, value);
+        return result;
+    }
+}


### PR DESCRIPTION
Added support for objects 


  @Test
  @SuppressWarnings("unchecked")
  void produces_a_JWT_with_the_supplied_object_claims() {
    DecodedJWT decodedJwt = verifyHs256AndDecodeForTemplate(
        "{{jwt claims=(object role='test' inheritedRole='test')}}");

    Map<String, Object> claims = decodedJwt.getClaim("claims").as(Map.class);
    String role = (String) claims.get("role");
    String inheritedRole = (String) claims.get("inheritedRole");
    assertThat(role, is("test"));
    assertThat(inheritedRole, is("test"));
  }

  @Test
  @SuppressWarnings("unchecked")
  void produces_a_JWT_with_the_supplied_object_nested_claims() {
    DecodedJWT decodedJwt = verifyHs256AndDecodeForTemplate(
        "{{jwt firstLevel=(object secondLevel=(object roles=(claims 'admin' 'user' 'billing')))}}");

    Map<String, Object> firstLevel = decodedJwt.getClaim("firstLevel").as(Map.class);
    Map<String, Object> secondLevel = (Map<String, Object>) firstLevel.get("secondLevel");
    List<String> roles = (List<String>) secondLevel.get("roles");
    assertThat(roles, hasItems("admin", "user", "billing"));
  }