### PR TITLE
Added object extension helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ You can also set any custom claim you wish via named parameters e.g.
 ```
 {% endraw %}
 
+You can also add list of claims 
+
+{% raw %}
+```handlebars
+{{{jwt roles=(claims 'admin' 'user' 'billing')}}}
+```
+{% endraw %}
+
+Or even nested objects
+{% raw %}
+```handlebars
+{{{jwt access=(claimsObject roles=(claims 'admin' 'user' 'billing'))}}}
+```
+
+```handlebars
+{{jwt firstLevel=(claimsObject secondLevel=(claimsObject roles=(claims 'admin' 'user' 'billing')))}}
+```
+{% endraw %}
+
+
 ### Signing with RS256
 
 By setting the `alg` parameter, the token can be signed using the public/private key

--- a/src/main/java/org/wiremock/extension/jwt/ClaimsObjectHandlebarsHelper.java
+++ b/src/main/java/org/wiremock/extension/jwt/ClaimsObjectHandlebarsHelper.java
@@ -1,0 +1,25 @@
+package org.wiremock.extension.jwt;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.jknack.handlebars.Options;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
+
+public class ClaimsObjectHandlebarsHelper extends HandlebarsHelper<Object> {
+
+    @Override
+    public Object apply(Object context, Options options) {
+        Map<String, Object> result = new HashMap<>();
+
+        // Process each key-value pair from the options hash
+        options.hash.forEach((key, value) -> {
+            // Convert each key-value pair to a nested structure if the key contains dots
+            Map<String, Object> map = new HashMap<>();
+            map.put(key, value);
+            result.putAll(map);
+        });
+
+        return result;
+    }
+}

--- a/src/main/java/org/wiremock/extension/jwt/ClaimsObjectHandlebarsHelper.java
+++ b/src/main/java/org/wiremock/extension/jwt/ClaimsObjectHandlebarsHelper.java
@@ -11,7 +11,6 @@ public class ClaimsObjectHandlebarsHelper extends HandlebarsHelper<Object> {
     @Override
     public Object apply(Object context, Options options) {
         Map<String, Object> result = new HashMap<>();
-
         // Process each key-value pair from the options hash
         options.hash.forEach((key, value) -> {
             // Convert each key-value pair to a nested structure if the key contains dots

--- a/src/main/java/org/wiremock/extension/jwt/JwtHandlebarsHelper.java
+++ b/src/main/java/org/wiremock/extension/jwt/JwtHandlebarsHelper.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -98,6 +99,8 @@ public class JwtHandlebarsHelper extends HandlebarsHelper<Object> {
                         builder.withClaim(key, (Date) value);
                     } else if (value instanceof List) {
                         toArray(builder, key, (List<?>) value);
+                    } else if (value instanceof Map) {
+                        builder.withClaim(key, (Map<String, Object>) value);
                     }
                 });
     }

--- a/src/main/java/org/wiremock/extension/jwt/JwtHelpersExtension.java
+++ b/src/main/java/org/wiremock/extension/jwt/JwtHelpersExtension.java
@@ -19,8 +19,8 @@ public class JwtHelpersExtension implements TemplateHelperProviderExtension {
         return Map.of(
                 "jwt", jwtHandlebarsHelper,
                 "claims", new ClaimListHandlebarsHelper(),
-                "jwks", jwksHandlebarsHelper
-        );
+                "claimsObject", new ClaimsObjectHandlebarsHelper(),
+                "jwks", jwksHandlebarsHelper);
     }
 
     @Override


### PR DESCRIPTION
Adds support for object structure claims inside the jwt 
## References
- https://github.com/wiremock/wiremock-jwt-extension/issues/5)

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x ] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
